### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 
 ## Features
 
-- Parse `level.dat` ([player.dat format](https://minecraft.fandom.com/Player.dat_format)).
-- Parse region file ([anvil format](https://minecraft.fandom.com/Anvil_file_format)) and chunks within the region.
-- Parse `raids.dat` file ([raids format](https://minecraft.fandom.com/Raids.dat_format)).
-- Parse poi file ([anvil format](https://minecraft.fandom.com/Anvil_file_format)).
+- Parse `level.dat` ([player.dat format](https://minecraft.wiki/w/Player.dat_format)).
+- Parse region file ([anvil format](https://minecraft.wiki/w/Anvil_file_format)) and chunks within the region.
+- Parse `raids.dat` file ([raids format](https://minecraft.wiki/w/Raids.dat_format)).
+- Parse poi file ([anvil format](https://minecraft.wiki/w/Anvil_file_format)).
 - Includes examples to quickly perform analysis, listing, etc. (check `cli` folder).
 - Based on [nbtlib](https://github.com/vberlier/nbtlib/) library.
 - Inspired by [twoolie's NBT](https://github.com/twoolie/NBT).

--- a/minenbt/cli/add_to_inventory.py
+++ b/minenbt/cli/add_to_inventory.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 from .utils import backup_save, find_player, get_player_file
 
-# From https://minecraft.fandom.com/File:Items_slot_number.png
+# From https://minecraft.wiki/w/File:Items_slot_number.png
 _SLOTS = set(range(9, 36))
 
 

--- a/minenbt/cli/biome_analysis.py
+++ b/minenbt/cli/biome_analysis.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 from .utils import get_world
 
-# https://minecraft.fandom.com/Java_Edition_data_values#Biomes
+# https://minecraft.wiki/w/Java_Edition_data_values#Biomes
 BIOMES = {
     0: "Ocean",
     1: "Plains",

--- a/minenbt/file_formats.py
+++ b/minenbt/file_formats.py
@@ -111,12 +111,12 @@ class Section(CompoundTag):
 class Chunk(CompoundTag):
     """Chunks store the terrain and entities within a 16×384×16 area.
 
-    https://minecraft.fandom.com/Chunk_format"""
+    https://minecraft.wiki/w/Chunk_format"""
 
     def section(self, i: int) -> Section | None:
         """Return a vertical section of the chunk, if available"""
         if self["DataVersion"].py_int >= 2529:
-            # https://minecraft.fandom.com/Java_Edition_20w17a
+            # https://minecraft.wiki/w/Java_Edition_20w17a
             return Section(self["sections"][i + 1])
         raise ValueError("DataVersion {} not supported".format(self["DataVersion"]))
 

--- a/minenbt/savefolder.py
+++ b/minenbt/savefolder.py
@@ -90,7 +90,7 @@ class Dimension:
 class SaveFolder:
     """A Minecraft Save Folder"""
 
-    # https://minecraft.fandom.com/Java_Edition_level_format
+    # https://minecraft.wiki/w/Java_Edition_level_format
 
     def __init__(self, folder: str | Path) -> None:
         self._folder = Path(folder)

--- a/minenbt/utils.py
+++ b/minenbt/utils.py
@@ -90,7 +90,7 @@ def near_chunks(x, z, distance) -> list[Coord]:
 def parse_uuid(compound: CompoundTag, prefix="UUID") -> UUID:
     """Return an uuid.UUID from a compund tag.
 
-    See https://minecraft.fandom.com/UUID"""
+    See https://minecraft.wiki/w/UUID"""
     # From MC 1.16
     ints = compound[prefix]
     if not isinstance(ints, IntArrayTag):


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki